### PR TITLE
Issue #153. feat(api): implement remove saved job endpoint for students

### DIFF
--- a/backend/controllers/savedJobs.controller.js
+++ b/backend/controllers/savedJobs.controller.js
@@ -28,3 +28,35 @@ export const getSavedJobs = async (req, res) => {
     res.status(500).json({ message: "Internal Server Error" });
   }
 };
+
+export const unsaveJob = async (req, res) => {
+  try {
+    const { jobId } = req.params;
+    const userId = req.userId; // set by protectRoute
+
+    // Check if job exists
+    const job = await JobPosting.findById(jobId);
+    if (!job) {
+      return res.status(404).json({ message: "Job not found." });
+    }
+
+    // Remove jobId from SavedJobs
+    const updatedStudent = await Student.findOneAndUpdate(
+      { user: userId },
+      { $pull: { SavedJobs: jobId } },
+      { new: true }
+    );
+
+    if (!updatedStudent) {
+      return res.status(404).json({ message: "Student not found or not authorized." });
+    }
+
+    return res.status(200).json({
+      message: "Job unsaved successfully.",
+      savedJobs: updatedStudent.SavedJobs,
+    });
+  } catch (error) {
+    console.error("Unsave job error:", error);
+    return res.status(500).json({ message: "Failed to unsave job." });
+  }
+};

--- a/backend/routes/savedJobs.route.js
+++ b/backend/routes/savedJobs.route.js
@@ -1,8 +1,11 @@
 import express from "express";
 import { protectRoute } from "../middleware/auth.middleware.js";
-import { saveJob, getSavedJobs } from "../controllers/savedJobs.controller.js";
+import { saveJob, getSavedJobs, unsaveJob } from "../controllers/savedJobs.controller.js";
 
 const router = express.Router();
+
 router.post("/save", protectRoute, saveJob);
 router.get("/saved", protectRoute, getSavedJobs);
+router.delete("/saved/:jobId", protectRoute, unsaveJob);
+
 export default router;


### PR DESCRIPTION
This PR implements the backend support for removing (unsaving) a saved job from a student’s profile.
Previously, students could save jobs, but there was no API to remove them. This feature closes that gap by introducing a dedicated DELETE endpoint.

**Changes Made**

- Added a DELETE API endpoint: DELETE /api/saved/:jobId.
- Implemented controller method unsaveJob in savedJobs.controller.js.
- Validates if the jobId exists.
- Removes the given job from the student’s SavedJobs array.
- Handles errors (job not found, student not found, unauthorized access).
- Updated router to include the new unsaveJob endpoint.
- Returns a success response with the updated list of saved jobs on successful removal.

**Example response:** 
{
  "message": "Job unsaved successfully.",
  "savedJobs": ["64fb0c3a2e9a...", "64fb0c8a7d12..."]
}

**Related Issue**

Closes #153 — [Hacktoberfest-25] feat: Implement "Remove Saved Job" API