### PR TITLE
refactor: use httpOnly cookies for authentication instead of localStorage

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -175,7 +175,12 @@ export const login = async (req, res) => {
 
 export const logout = async (req, res) => {
     try {
-        res.cookie("jwt", "", { maxAge: 0 });
+        res.clearCookie("jwt", {
+            path: "/",
+            httpOnly: true,
+            secure: true,
+            sameSite: "strict"
+        })
         res.status(200).json({ success: true, message: "Logged out successfully" });
     } catch (e) {
         console.log("error in logout controller", e.message);

--- a/frontend/src/api/auth/useLogin.js
+++ b/frontend/src/api/auth/useLogin.js
@@ -17,6 +17,7 @@ import { useAppContext } from '../../context/AppContext.jsx';
                 headers: {
                     "Content-Type": "application/json"
                 },
+                credentials: "include",
                 body: JSON.stringify({email, password})
             
             })
@@ -29,7 +30,6 @@ import { useAppContext } from '../../context/AppContext.jsx';
                 throw new Error(data.message)
             }
             localStorage.setItem("ccps-user", JSON.stringify(data.userData))
-            localStorage.setItem("ccps-token", data.token)
             setAuthUser(data)
             toast.success("Login Successful!");
         }

--- a/frontend/src/api/auth/useLogout.js
+++ b/frontend/src/api/auth/useLogout.js
@@ -24,7 +24,7 @@ const useLogout = () => {
       }
 
       localStorage.removeItem('ccps-user');
-      localStorage.removeItem('ccps-token');
+      
       setAuthUser(null);
       toast.success('Logged out successfully!');
       navigate('/login');

--- a/frontend/src/api/auth/useSignup.js
+++ b/frontend/src/api/auth/useSignup.js
@@ -18,6 +18,7 @@ const useSignup = () => {
                 headers: {
                     'Content-Type': 'application/json'
                 },
+                credentials:"include",
                 body: JSON.stringify({ name, email, password, role })
             })
             const data = await res.json();


### PR DESCRIPTION
Remove token handling in localStorage from frontend login flow.

Update frontend API calls to include credentials:
fetch(..., { credentials: "include" })

Ensure logout clears the cookie using res.clearCookie in the backend

## when the user login or signup the jwt token will store in httpOnly cookie

<img width="672" height="124" alt="Screenshot 2025-10-01 153148" src="https://github.com/user-attachments/assets/46f57079-ae7f-43ab-812d-6ef7d506c209" />

## when the user logout the jwt token will be removed by res.clearCookie()

<img width="667" height="245" alt="Screenshot 2025-10-01 153221" src="https://github.com/user-attachments/assets/af028114-a76e-49fe-a735-07284a6c35ab" />

