### PR TITLE
setup modal for adding and updating alumni

### DIFF
--- a/frontend/src/components/AddEditAlumniModal.jsx
+++ b/frontend/src/components/AddEditAlumniModal.jsx
@@ -14,7 +14,7 @@ const initialForm = {
   jobs: [{ id: "", role: "" }],
 };
 
-const AddEditAlumniModal = ({ alumni, alumniList, setAlumniList, onClose }) => {
+const AddEditAlumniModal = ({ alumni, alumniList, onAddAlumni, onUpdateAlumni, onDeleteAlumni, onClose }) => {
   const { addAlumni, updateAlumni, deleteAlumni } = useAlumniAdmin();
 
   const [searchId, setSearchId] = useState("");
@@ -79,11 +79,13 @@ const AddEditAlumniModal = ({ alumni, alumniList, setAlumniList, onClose }) => {
     const token = localStorage.getItem("ccps-token");
     try {
       if (isEditMode && editingId) {
+        console.log("Updating alumni:", editingId, form);
         await updateAlumni(editingId, form, token);
-        setAlumniList(alumniList.map((a) => (a._id === editingId ? { ...a, ...form } : a)));
+        onUpdateAlumni({...form, _id: editingId});
       } else {
+        console.log("Adding new alumni:", form);
         await addAlumni(form, token);
-        setAlumniList([...alumniList, form]);
+        onAddAlumni(form);
       }
       resetForm();
       onClose();
@@ -100,7 +102,7 @@ const AddEditAlumniModal = ({ alumni, alumniList, setAlumniList, onClose }) => {
       try {
         await deleteAlumni(editingId, token);
         resetForm();
-        setAlumniList(alumniList.filter((a) => a._id !== editingId));
+        onDeleteAlumni(editingId);
         onClose();
       } catch (error) {
         console.error(err);

--- a/frontend/src/components/AlumniCard.jsx
+++ b/frontend/src/components/AlumniCard.jsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from "react";
 import { useMenuClose } from "../utils/closeMenuEffect";
 
-function AlumniCard({ alum, index, authUser, onEditAlumni }) {
+function AlumniCard({ alum, index, authUser, onEditAlumni, onDeleteAlumni }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuRef = useRef(null);
 
@@ -9,8 +9,13 @@ function AlumniCard({ alum, index, authUser, onEditAlumni }) {
     setIsMenuOpen(!isMenuOpen);
   };
 
-  const handleEditAlumni = () => {
-    onEditAlumni();
+  const handleEditAlumni = (id) => {
+    onEditAlumni(id);
+    setIsMenuOpen(false);
+  };
+
+  const handleDeleteAlumni = (id) => {
+    onDeleteAlumni(id);
     setIsMenuOpen(false);
   };
 
@@ -38,6 +43,7 @@ function AlumniCard({ alum, index, authUser, onEditAlumni }) {
             {isMenuOpen && (
               <ul tabIndex={index} className="absolute right-0 z-10 mt-2 w-48 bg-white rounded-md shadow-lg py-1 ring-1 ring-black ring-opacity-5">
                 <li><button onClick={handleEditAlumni} className="block w-full px-4 py-2 text-center text-sm text-gray-700 hover:bg-gray-100 focus:outline-hidden">Edit</button></li>
+                <li><button onClick={handleDeleteAlumni} className="block w-full px-4 py-2 text-center text-sm text-red-600 hover:bg-gray-100 focus:outline-hidden">Delete</button></li>
               </ul>
             )}
           </div>

--- a/frontend/src/pages/student/Alumni.jsx
+++ b/frontend/src/pages/student/Alumni.jsx
@@ -6,6 +6,8 @@ import useGetAllAlumni from "../../api/alumni/useGetAllAlumni";
 import { useAuthContext } from '../../context/AuthContext';
 import AddEditAlumniModal from "../../components/AddEditAlumniModal";
 import AlumniCard from "../../components/AlumniCard";
+import useAlumniAdmin from "../../api/alumni/useAlumniAdmin";
+import toast from "react-hot-toast";
 
 const Alumni = () => {
   const { authUser } = useAuthContext();
@@ -17,6 +19,7 @@ const Alumni = () => {
 
   const { loading: loadingAll, alumni } = useGetAllAlumni();
   const { loading: loadingSearch, getAlumni } = useGetAlumni();
+  const { deleteAlumni } = useAlumniAdmin();
 
   useEffect(() => {
     setAlumniList(alumni);
@@ -40,6 +43,19 @@ const Alumni = () => {
     }
   };
 
+  const handleDeleteAlumni = (id) => async () => {
+    const token = localStorage.getItem("ccps-token");
+    if (!id) return;
+    if (window.confirm("Are you sure you want to delete this alumni?")) {
+      try {
+        await deleteAlumni(id, token);
+        setAlumniList(alumniList.filter((a) => a._id !== id));
+      } catch (error) {
+        toast.error("Failed to delete alumni");
+      }
+    }
+  }
+
   const openAddEditModal = (alumni) => {
     setSelectedAlumni(alumni);
     setIsModalOpen(true);
@@ -49,6 +65,24 @@ const Alumni = () => {
     setIsModalOpen(false);
     setSelectedAlumni(null);
   };
+
+  const onAddNewAlumni = (newAlumni) => {
+    // Add the new alumni to the list
+    setAlumniList([...alumniList, newAlumni]);
+    setIsModalOpen(false);
+  };
+
+  const onUpdateExistingAlumni = (updatedAlumni) => {
+    // Update the alumni in the list
+    setAlumniList(alumniList.map((a) => (a._id === updatedAlumni._id ? { ...a, ...updatedAlumni } : a)));
+    setIsModalOpen(false);
+  };
+
+  const onDeleteExistingAlumni = (id) => {
+    // Remove the alumni from the list
+    setAlumniList(alumniList.filter((a) => a._id !== id));
+    setIsModalOpen(false);
+  }
 
   const labelMap = {
     company: "Company Name",
@@ -122,6 +156,7 @@ const Alumni = () => {
                   index={index} 
                   authUser={authUser}
                   onEditAlumni={handleEditAlumni(alum._id)}
+                  onDeleteAlumni={handleDeleteAlumni(alum._id)}
                   />
               ))}
             </div>
@@ -134,7 +169,9 @@ const Alumni = () => {
         <AddEditAlumniModal
           alumni={selectedAlumni}
           alumniList={alumniList}
-          setAlumniList={setAlumniList}
+          onAddAlumni={onAddNewAlumni}
+          onUpdateAlumni={onUpdateExistingAlumni}
+          onDeleteAlumni={onDeleteExistingAlumni}
           onClose={closeAddEditModal}
         />
       )}


### PR DESCRIPTION
PR Overview:

- Addresses issue #160 
- Moves the form in the `AddAlumni.jsx` page to a modal component that can be called in the `student/Alumni.jsx` page.
- Adds `Add Alumni` button to display modal to add a new alumni. The page is refreshed on successful action.
- Adds `Edit` button for opening the modal with the details of the selected alumni for update. The page is refreshed on successful action.
- Removes kebab delete button since that is already part of the add or edit modal.
- Creates Alumni card for each alumni to maintain state better when opening the kebab menu.

<img width="1362" height="593" alt="Screenshot 2025-10-09 at 12 32 59 PM" src="https://github.com/user-attachments/assets/b5f9bffb-d3eb-41d7-9fc2-08211b0079e7" />
<img width="1366" height="898" alt="Screenshot 2025-10-09 at 12 33 12 PM" src="https://github.com/user-attachments/assets/a9368e0e-e738-4889-a94a-90af97f2778e" />
<img width="1366" height="769" alt="Screenshot 2025-10-09 at 12 33 32 PM" src="https://github.com/user-attachments/assets/c60518d1-5878-447a-a030-f49119d47d19" />
<img width="1365" height="888" alt="Screenshot 2025-10-09 at 12 33 43 PM" src="https://github.com/user-attachments/assets/db604c73-84f5-4a9d-81e9-b30bba284d6e" />
<img width="1364" height="1009" alt="Screenshot 2025-10-09 at 12 34 19 PM" src="https://github.com/user-attachments/assets/f4c15f88-9dde-4946-a936-aae168d0f559" />

