### PR TITLE
feat(jobs): implement filtering, pagination, and sorting for job listings

### DIFF
--- a/backend/controllers/jobs.controllers.js
+++ b/backend/controllers/jobs.controllers.js
@@ -216,30 +216,26 @@ export const jobList = async (req, res) => {
           as: "jobApplications"
         }
       });
-      if (sortBy && sortBy !== "relevanceScore") {
-        return res.status(400).json({ message: "Invalid sort field" });
-      }
-      
       //validation of sort if given
+      if (sortBy && sortBy !== "relevanceScore") {
+          return res.status(400).json({ message: "Invalid sort field" });
+      }
+    
       if (order && !["asc", "desc"].includes(order)) {
-        return res.status(400).json({ message: "Invalid sort order" });
-        }
-        
-      // sortingg
-      // Sorting
+          return res.status(400).json({ message: "Invalid sort order" });
+      }
       if (sortBy === "relevanceScore") {
-        pipeline.push({
-        $sort: {
-            relevanceScore: order === "asc" ? 1 : -1,
-            _id: 1 // secondary stable sort
-        }
-        });
+          pipeline.push({
+          $sort: {
+              relevanceScore: order === "asc" ? 1 : -1,
+              _id: 1 
+          }
+          });
       } else {
-        // Default stable sort to ensure consistent pagination
-        pipeline.push({
-        $sort: { _id: 1 }
-        });
-    }
+          pipeline.push({
+          $sort: { _id: 1 }
+          });
+      }
     
   
       // Pagination


### PR DESCRIPTION
Closes #28 

## What this PR does
- Adds filter support to the job listing API. Supports filtering by type, company, batch, author, and skills. Adds pagination using page and limit query parameters.Adds optional sorting by relevanceScore. Preserves existing jobApplications lookup via aggregation

## Validation & Edge Cases
- Validates job type enum
- Validates pagination limits
- Validates sort order
- Escapes regex input for company filter
- Handles empty filters gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic job search and filtering by type, company, batch, skill, and author
  * Pagination for browsing job listings with page/limit returned
  * Sorting of results (including relevance-based ordering)
  * Job listings include related application info/counts

* **Bug Fixes**
  * Improved input validation and clearer error responses for invalid queries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->